### PR TITLE
Make the PublishedResource model comply with the new model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ npm-debug.log*
 yarn-error.log
 testem.log
 .DS_Store
+.idea
 
 *~
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # besluit-publicatie-publish-service
+
 This service polls for [signing:PublishedResource](http://mu.semte.ch/vocabularies/ext/signing/PublishedResource), a derived resource from gelinkt-notuleren notulen.
 The service extracts data and maps it to applicatieprofiel [Besluit Publicatie](https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/)
 
 ## Rest API
+
 For debugging:
+
 - `POST /publish-tasks`: starts publishing tasks# besluit-publicatie-publish-service
 
 ## Params
+
 ```
 besluit-publicatie:
     image: lblod/besluit-publicatie-publish-service:z.y.x
@@ -18,6 +22,7 @@ besluit-publicatie:
 ```
 
 ## Example delta notifier config
+
 ```
 export default [
   {
@@ -36,10 +41,29 @@ export default [
   }
 ]
 ```
+
 ## Inner workings
+
 Takes a published resource as input, tries to extract data from it. Removes old data.
 Assummes all snippets contain a zitting and bestuursorgaan.
 
+## model
+
+### PublishedResource
+
+#### Class
+
+`ext:PublishedResource`
+
+#### Properties
+
+| Name                | Predicate                                                  | Range | Definition                 |
+| ------------------- | ---------------------------------------------------------- | ----- | -------------------------- |
+| `created`           | `purl:created`                                             |       |                            |
+| `number-of-retries` | `ext:besluit-publicatie-publish-service/number-of-retries` |       |                            |
+| `status`            | `ext:besluit-publicatie-publish-service/status`            |       |                            |
+| `content`           | `sign:text`                                                |       | The published html snippet |
 
 ## TODOS
-*  some general cleanup/documenting
+
+- some general cleanup/documenting

--- a/support/queries.js
+++ b/support/queries.js
@@ -28,15 +28,11 @@ async function getUnprocessedPublishedResources(pendingTimeout, maxAttempts = 10
          OPTIONAL{
             ?resource <http://mu.semte.ch/vocabularies/ext/besluit-publicatie-publish-service/status> ?status.
          }
+         ?resource sign:text ?content
 
-         ?resource <http://purl.org/dc/terms/subject> ?versionedDocument.
-         ?versionedDocument <http://mu.semte.ch/vocabularies/ext/content> ?content.
 
-         OPTIONAL{
-            ?versionedDocument <http://mu.semte.ch/vocabularies/ext/publicContent> ?publicContent.
-         }
 
-         BIND(coalesce(?publicContent, ?content) as ?rdfaSnippet).
+         BIND(?content as ?rdfaSnippet).
 
          FILTER (
           (!BOUND(?status)


### PR DESCRIPTION
Uses the `text` property of the PublishedResource to get the rendered html content