### PR TITLE
Feature/deal with broken ordering of aps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "besluit-publicatie-publish-service",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "mu-semtech service to extract triples from PublishedResources and map to Publicatie Besluit",
   "main": "app.js",
   "dependencies": {

--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -21,7 +21,7 @@ async function startPipeline(resourceToPublish){
   let contexts = analyse( doc.getTopDomNode() );
   let triples = flatTriples(contexts.map((c) => c.context));
   triples = preProcess(triples);
-  
+
   await insertZitting(triples, resourceToPublish);
   await insertAgenda(triples, resourceToPublish);
   await insertUittreksel(triples, resourceToPublish, doc, contexts);
@@ -219,16 +219,16 @@ function orderGebeurtNa(triples, type = 'http://data.vlaanderen.be/ns/besluit#Ag
   //written for Agendapunten, works on behandeling van agendapunten too.
   //assumes AP's are a list.
   //assumes no duplicates
-  let orderedPunten = [];
-  let orderAps = triples.filter(t => t.predicate == gebeurtNa);
+  let childAps = triples.filter(t => t.predicate == gebeurtNa);
 
-  if(orderAps.length == 0) return triples;
+  if(childAps.length == 0) return triples;
 
   //find first agendapunt as uri
   let ap1 = triples
         .filter(e => e.predicate == 'a' && e.object == type)
         .map(t => t.subject)
         .find(t => !orderAps.map(t => t.subject).find(uri => uri == t));
+  let ap1 = rootAps[0];
 
   if(!ap1) return triples;
 
@@ -237,8 +237,8 @@ function orderGebeurtNa(triples, type = 'http://data.vlaanderen.be/ns/besluit#Ag
 
   triples.push({subject: ap1 , predicate: 'http://schema.org/position' , object: currIndex });
 
-  while(currIndex < orderAps.length){
-    let nextAp = orderAps.find(t => t.object == currAp);
+  while(currIndex < childAps.length){
+    let nextAp = childAps.find(t => t.object == currAp);
     currIndex += 1;
     triples.push({subject: nextAp.subject , predicate: 'http://schema.org/position' , object: currIndex });
     currAp = nextAp.subject;

--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -223,11 +223,24 @@ function orderGebeurtNa(triples, type = 'http://data.vlaanderen.be/ns/besluit#Ag
 
   if(childAps.length == 0) return triples;
 
-  //find first agendapunt as uri
-  let ap1 = triples
+  //TODO: this filtering seems a bit complex...
+  const rootAps = triples
         .filter(e => e.predicate == 'a' && e.object == type)
         .map(t => t.subject)
-        .find(t => !orderAps.map(t => t.subject).find(uri => uri == t));
+        .filter(t => !childAps.map(t => t.subject).find(uri => uri == t));
+
+  if(rootAps.length > 1){
+    console.warn(`Found ${rootAps.length} potential root APs or bvAPs`);
+    console.warn(`This is probably unexpected. This case is unsupported anyway.`);
+    console.warn(`Returning random order. See also ${rootAps.join('\n')} for broken data.`);
+
+    rootAps.forEach( (s, currIndex) => {
+      triples.push({ subject: s , predicate: 'http://schema.org/position' , object: currIndex });
+    });
+
+    return triples;
+  }
+
   let ap1 = rootAps[0];
 
   if(!ap1) return triples;


### PR DESCRIPTION
If multiple root agendapointen were provided, the code crashed. (Because probably broken data) Now we don't crash, we just return a random order.