### PR TITLE
Filter out triples with whitespace object

### DIFF
--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -312,6 +312,11 @@ function preProcess(triples){
     }
     return t;
   });
+  
+  //Remove triples with empty objects
+  //We found that the RDFa parser did not handle spaces correctly and created triples where the object URI is a ' '.
+  triples = triples.filter((t => t.object.trim().length > 0));
+
   return triples;
 };
 

--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -315,7 +315,10 @@ function preProcess(triples){
   
   //Remove triples with empty objects
   //We found that the RDFa parser did not handle spaces correctly and created triples where the object URI is a ' '.
-  triples = triples.filter((t => t.object.trim().length > 0));
+  triples = triples.filter(((t) => 
+    !(t.datatype === 'http://www.w3.org/2000/01/rdf-schema#Resource' &&
+      t.object.trim().length < 1)
+  ));
 
   return triples;
 };


### PR DESCRIPTION
A more complete backstory:

While editing an agendapoint in Gelinkt Notuleren, you can set and change the type of the besluit. When changing this type multiple times in a row, there would be some leftover spaces in the RDFa data (which is not illegal). For example:
```html
<div ... typeof="besluit:Besluit ext:BesluitNieuweStijl     besluittype:849c66c2-ba33-4ac1-a693-be48d8ac7bc7" ...>
```
This caused the RDFa parser to find the types:
```javascript
[ "besluit:Besluit", "ext:BesluitNieuweStijl", " ", " ", " ", "besluittype:849c66c2-ba33-4ac1-a693-be48d8ac7bc7" ]
```
and eventually created SPARQL queries like:
```sparql
INSERT DATA {
  GRAPH <http://mu.semte.ch/graphs/public> {
    besluiten:0ae32940-b70d-11ec-ac2b-ed7850dc94ca a besluit:Besluit ;
      a ext:BesluitNieuweStijl ;
      a <> ;
      a besluittype:849c66c2-ba33-4ac1-a693-be48d8ac7bc7 .
    ...
  }
}
```
where the empty IRI `<>` caused the query to fail.

In some situations, the service retries to publish resources up to 10 times until it eventually permanently fails to publish the resource. Every resources is published using multiple queries, and only 1 would not succeed, leaving some leftover data in the database that is not rolled back. This could cause 'phantom' uittreksels to show in the publicatie frontend, 10 to be exact:
![image](https://user-images.githubusercontent.com/12394202/162784627-cace459e-a27e-4ae7-8542-adda722c5353.png)

This PR hopefully fixes this, by filtering out triples with empty (or white space) objects. A more complete fix would be to use a different RDFa parser that would properly handle multiple spaces.