### PR TITLE
Feature/add regulatory statement to besluit

### DIFF
--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -378,6 +378,7 @@ function getBesluiten(triples){
     'http://www.w3.org/ns/prov#value',
     'http://www.w3.org/ns/prov#wasDerivedFrom',
     'http://mu.semte.ch/vocabularies/ext/besluitPublicatieLinkedBesluit',
+    'http://purl.org/dc/terms/hasPart'
   ];
 
   trs = triples.filter(t => trs.find(a => a.subject == t.subject) && poi.find(p => p == t.predicate));

--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -76,6 +76,8 @@ async function insertBesluitenlijst(triples, resourceToPublish){
   let stemmingen = getStemmingen(triples);
   stemmingen = postProcess(stemmingen);
 
+  
+
   await persistExtractedData([...besluitenlijstTrps, ...bvaps, ...besluiten, ...stemmingen]);
 }
 
@@ -361,7 +363,6 @@ async function hashStr(message){
 
 function getBesluiten(triples){
   let trs = triples.filter(e => e.predicate == 'a' && e.object == 'http://data.vlaanderen.be/ns/besluit#Besluit');
-
   //We are conservative in what to persist; we respect applicatieprofiel
   let poi = [
     'a',
@@ -378,7 +379,7 @@ function getBesluiten(triples){
     'http://www.w3.org/ns/prov#value',
     'http://www.w3.org/ns/prov#wasDerivedFrom',
     'http://mu.semte.ch/vocabularies/ext/besluitPublicatieLinkedBesluit',
-    'http://purl.org/dc/terms/hasPart'
+    'http://data.europa.eu/eli/ontology#related_to'
   ];
 
   trs = triples.filter(t => trs.find(a => a.subject == t.subject) && poi.find(p => p == t.predicate));

--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -76,8 +76,6 @@ async function insertBesluitenlijst(triples, resourceToPublish){
   let stemmingen = getStemmingen(triples);
   stemmingen = postProcess(stemmingen);
 
-  
-
   await persistExtractedData([...besluitenlijstTrps, ...bvaps, ...besluiten, ...stemmingen]);
 }
 

--- a/support/queries.js
+++ b/support/queries.js
@@ -253,7 +253,8 @@ const predicateDataTypeEscapeMap = function ( predicate ){
     { escapeSubjectF: sparqlEscapeUri, predicate: 'http://data.europa.eu/eli/ontology#has_part', escapeObjectF: sparqlEscapeString },
     { escapeSubjectF: sparqlEscapeUri, predicate: 'http://www.w3.org/ns/prov#value', escapeObjectF: sparqlEscapeString },
     { escapeSubjectF: sparqlEscapeUri, predicate: 'http://www.w3.org/ns/prov#wasDerivedFrom', escapeObjectF: sparqlEscapeUri },
-    { escapeSubjectF: sparqlEscapeUri, predicate: 'http://mu.semte.ch/vocabularies/ext/besluitPublicatieLinkedBesluit', escapeObjectF: sparqlEscapeUri }
+    { escapeSubjectF: sparqlEscapeUri, predicate: 'http://mu.semte.ch/vocabularies/ext/besluitPublicatieLinkedBesluit', escapeObjectF: sparqlEscapeUri },
+    { escapeSubjectF: sparqlEscapeUri, predicate: 'http://data.europa.eu/eli/ontology#related_to', escapeObjectF: sparqlEscapeUri }
     ];
 
   let bvap = [

--- a/support/queries.js
+++ b/support/queries.js
@@ -18,7 +18,7 @@ async function getUnprocessedPublishedResources(graph, pendingTimeout, maxAttemp
     PREFIX publicationStatus: <http://mu.semte.ch/vocabularies/ext/signing/publication-status/>
 
      SELECT DISTINCT ?graph ?resource ?rdfaSnippet ?status ?created ?numberOfRetries {
-       BIND(${sparqlEscapeUri(graph)} as ?graph)
+       VALUES ?graph { ${sparqlEscapeUri(graph)} }
        GRAPH ?graph {
          ?resource a sign:PublishedResource;
                    <http://purl.org/dc/terms/created> ?created.


### PR DESCRIPTION
Modify the service so it only finds and persists the triple with `http://data.europa.eu/eli/ontology#related_to` predicate in order to support regulatory statement filtering on gn-publicatie.
Niels I had to change the BIND for VALUES, but not sure if this is necesary in production