### PR TITLE
Improve parsing performance and save the processed html as a file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,8 @@
   "description": "mu-semtech service to extract triples from PublishedResources and map to Publicatie Besluit",
   "main": "app.js",
   "dependencies": {
-    "@lblod/marawa": "0.8.0-beta.3",
     "@lblod/mu-auth-sudo": "^0.3.2",
     "cron": "^1.3.0",
-    "graph-rdfa-processor": "^1.3.0",
     "jsdom": "^11.6.2",
     "rdfa-streaming-parser": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "@lblod/mu-auth-sudo": "^0.3.2",
     "cron": "^1.3.0",
     "graph-rdfa-processor": "^1.3.0",
-    "jsdom": "^11.6.2"
+    "jsdom": "^11.6.2",
+    "rdfa-streaming-parser": "^2.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.0.2",

--- a/support/annotate-decisions.js
+++ b/support/annotate-decisions.js
@@ -1,5 +1,5 @@
-import { expandURI } from "./rdf-utils";
 import { JSDOM } from "jsdom";
+import { expandURI } from "./rdf-utils";
 /** @typedef {import('./rdf-utils').Triple} Triple */
 /** @typedef {import('./rdfa-dom-document').default} RdfaDomDocument */
 

--- a/support/annotate-decisions.js
+++ b/support/annotate-decisions.js
@@ -1,0 +1,82 @@
+import { expandURI } from "./rdf-utils";
+import { JSDOM } from "jsdom";
+/** @typedef {import('./rdf-utils').Triple} Triple */
+/** @typedef {import('./rdfa-dom-document').default} RdfaDomDocument */
+
+
+function enrichBesluit(dom, besluitIRI, triples) {
+  const { document } = new JSDOM("").window;
+  const behandeling = triples.find(
+    (t) =>
+      expandURI(t.object) === expandURI(besluitIRI) &&
+      expandURI(t.predicate) === "http://www.w3.org/ns/prov#generated",
+  );
+  if (behandeling) {
+    const generatedLink = document.createElement("link");
+    generatedLink.setAttribute("property", "prov:wasGeneratedBy");
+    generatedLink.setAttribute("resource", behandeling.subject);
+    dom.append(generatedLink);
+
+    const zittingTriple = triples.find(
+      (t) =>
+        expandURI(t.object) === "http://data.vlaanderen.be/ns/besluit#Zitting",
+    ); // TODO: assumes one zitting!
+    const agendapuntTriple = triples.find(
+      (t) =>
+        expandURI(t.subject) === expandURI(behandeling.subject) &&
+        expandURI(t.predicate) === "http://purl.org/dc/terms/subject",
+    );
+    if (agendapuntTriple && zittingTriple) {
+      const agendapuntToZitting = document.createElement("link");
+      agendapuntToZitting.setAttribute("about", zittingTriple.subject);
+      agendapuntToZitting.setAttribute(
+        "property",
+        "http://data.vlaanderen.be/ns/besluit#behandelt",
+      );
+      agendapuntToZitting.setAttribute("resource", agendapuntTriple.object);
+      dom.append(agendapuntToZitting);
+    }
+  }
+  const pubDate = document.createElement("link");
+  pubDate.setAttribute(
+    "property",
+    "http://data.europa.eu/eli/ontology#date_publication",
+  );
+  pubDate.setAttribute("datatype", "xsd:date");
+  pubDate.setAttribute("content", new Date().toISOString().substring(0, 10));
+  dom.append(pubDate);
+  const gehoudenDoor = triples.find(
+    (t) =>
+      expandURI(t.predicate) ===
+      "http://data.vlaanderen.be/ns/besluit#isGehoudenDoor",
+  );
+  if (gehoudenDoor) {
+    const generatedLink = document.createElement("link");
+    generatedLink.setAttribute(
+      "property",
+      "http://data.europa.eu/eli/ontology#passed_by",
+    );
+    generatedLink.setAttribute("resource", gehoudenDoor.object);
+    dom.append(generatedLink);
+  }
+}
+/**
+ * Modifies doc in-place to add extra links to the decision nodes
+ * @param {RdfaDomDocument} doc
+ * @param {Triple[]} triples
+ * @returns {void}
+ */
+export function annotateDecisions(doc, triples) {
+  const decisionType = "http://data.vlaanderen.be/ns/besluit#Besluit";
+
+  const dom = doc.getTopDomNode();
+  // this is a rough selection which won't work in all cases, but I hope
+  // to eliminate this whole fudzing around by skipping most of the parsing this
+  // service does
+  const decisionNodes = dom.querySelectorAll(`[typeof~="${decisionType}"]`);
+  for (const node of decisionNodes) {
+    const decisionIRI =
+      node.getAttribute("about") ?? node.getAttribute("resource");
+    enrichBesluit(node, decisionIRI, triples);
+  }
+}

--- a/support/constants.js
+++ b/support/constants.js
@@ -1,0 +1,1 @@
+export const PUBLIC_GRAPH = "http://mu.semte.ch/graphs/public";

--- a/support/file-utils.js
+++ b/support/file-utils.js
@@ -49,7 +49,6 @@ export async function persistContentToFile(content, pathPrefix = []) {
 }
 
 export async function writeFileMetadataToDb(metadata) {
-  console.log(metadata);
   const logicalFileUuid = uuid();
   const logicalFileUri = `http://lblod.data.gift/files/${logicalFileUuid}`;
   const logicalFileName = metadata.filename;

--- a/support/file-utils.js
+++ b/support/file-utils.js
@@ -1,0 +1,92 @@
+import { stat, writeFile, readFile } from "fs/promises";
+import { existsSync, mkdirSync } from "fs";
+import { updateSudo as update } from "@lblod/mu-auth-sudo";
+// @ts-ignore
+import {
+  sparqlEscapeUri,
+  sparqlEscapeString,
+  sparqlEscapeDateTime,
+  uuid,
+  // eslint-disable-next-line import/no-unresolved
+} from "mu";
+import { PUBLIC_GRAPH } from "./constants";
+
+/**
+ * These utils are copied from https://github.com/lblod/notulen-prepublish-service/tree/6fc93af34659e70db3683d5f6f6223a269c1e65d/support/file-utils.js
+ */
+
+/**
+ * reads a file from the shared drive and returns its content
+ * @param {string} shareUri the uri of the file to read
+ * @return string
+ */
+export async function getFileContentForUri(shareUri) {
+  const path = shareUri.replace("share://", "/share/");
+  const content = await readFile(path, "utf8");
+  return content;
+}
+
+/**
+ * write contents to a file in the shared drive and return its path
+ * @param {string} content The content of the file
+ * @param {string[]?} pathPrefix Path entries joined with "/" and infixed like `/share/<pathPrefix>/filename.hml`. Entries should not contain slashes.
+ */
+export async function persistContentToFile(content, pathPrefix = []) {
+  const fileId = uuid();
+  const filename = `${fileId}.html`;
+  let path;
+  if (pathPrefix.length) {
+    const dir = `/share/${pathPrefix.join("/")}`;
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    path = `${dir}/${filename}`;
+  } else {
+    path = `/share/${filename}`;
+  }
+  await writeFile(path, content, "utf8");
+  return { uuid: fileId, path, filename };
+}
+
+export async function writeFileMetadataToDb(metadata) {
+  console.log(metadata);
+  const logicalFileUuid = uuid();
+  const logicalFileUri = `http://lblod.data.gift/files/${logicalFileUuid}`;
+  const logicalFileName = metadata.filename;
+  const fileStats = await stat(metadata.path);
+  const fileSize = fileStats.size;
+  const created = new Date();
+  const physicalFilename = metadata.filename;
+  const physicalFileUri = metadata.path.replace("/share/", "share://");
+  const fileQuery = `
+   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+   PREFIX prov: <http://www.w3.org/ns/prov#>
+   PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+   PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+   PREFIX dct: <http://purl.org/dc/terms/>
+   PREFIX dbpedia: <http://dbpedia.org/ontology/>
+   INSERT DATA {
+    GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)}{
+         ${sparqlEscapeUri(logicalFileUri)} a nfo:FileDataObject;
+                    nfo:fileName ${sparqlEscapeString(logicalFileName)};
+                    mu:uuid ${sparqlEscapeString(logicalFileUuid)};
+                    dct:format "text/html";
+                    dbpedia:fileExtension "html";
+                    nfo:fileSize ${fileSize};
+                    dct:created ${sparqlEscapeDateTime(created)};
+                    dct:modified ${sparqlEscapeDateTime(created)}.
+         ${sparqlEscapeUri(physicalFileUri)} a nfo:FileDataObject;
+                    nie:dataSource ${sparqlEscapeUri(logicalFileUri)};
+                    nfo:fileName ${sparqlEscapeUri(physicalFilename)};
+                    mu:uuid ${sparqlEscapeUri(metadata.uuid)};
+                    nfo:fileSize ${fileSize};
+                    dbpedia:fileExtension "html";
+                    dct:created ${sparqlEscapeDateTime(created)};
+                    dct:modified ${sparqlEscapeDateTime(created)}.
+            }
+  }`;
+
+  await update(fileQuery);
+  return logicalFileUri;
+}

--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-use-before-define */
-import { analyse } from "@lblod/marawa/rdfa-context-scanner";
 // eslint-disable-next-line import/no-unresolved
 import { uuid } from "mu";
 import crypto from "crypto";
+import { RdfaParser } from "rdfa-streaming-parser";
 import {
   persistExtractedData,
   belongsToType,
@@ -14,7 +14,6 @@ import {
 } from "./queries";
 import RdfaDomDocument from "./rdfa-dom-document";
 import { persistContentToFile, writeFileMetadataToDb } from "./file-utils";
-import { RdfaParser } from "rdfa-streaming-parser";
 import { annotateDecisions } from "./annotate-decisions";
 import {
   isURI,
@@ -498,13 +497,6 @@ function postProcess(triples) {
 }
 
 /*
- * flatten output from contextscanner
- */
-function flatTriples(contexts) {
-  return contexts.reduce((acc, e) => [...acc, ...e], []);
-}
-
-/*
  * hash string
  */
 async function hashStr(message) {
@@ -652,18 +644,4 @@ function getZittingResource(triples) {
   return trs;
 }
 
-/**
- * returns the first domNode where resource is the subject */
-function findNodeForResource(orderedContexts, resource) {
-  for (let idx = 0; idx < orderedContexts.length; idx += 1) {
-    const ctxObj = orderedContexts[idx];
-    for (let cdx = 0; cdx < ctxObj.context.length; cdx += 1) {
-      const triple = ctxObj.context[cdx];
-      if (expandURI(triple.subject) === expandURI(resource))
-        return ctxObj.semanticNode.domNode;
-    }
-  }
-  console.log(`Could not find resource ${resource}`);
-  return null;
-}
 export { startPipeline };

--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -33,7 +33,6 @@ import {
  *  - We extend AP with agenda, uittreksel and besluiten lijst. This eases management of extracted data.
  * */
 async function startPipeline(resourceToPublish) {
-  console.profile('pipeline');
   const doc = new RdfaDomDocument(resourceToPublish.rdfaSnippet);
   const triples = preProcess(
     dedupeTriples(parseRdfaIntoFlatTriples(resourceToPublish.rdfaSnippet)),
@@ -45,7 +44,6 @@ async function startPipeline(resourceToPublish) {
   await insertNotulen(triples, resourceToPublish, doc);
 
   await insertZittingPermalink(triples);
-  console.profileEnd('pipeline');
 }
 /**
  * @param {string} html

--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -23,6 +23,8 @@ import {
   RDF_TYPE,
 } from "./rdf-utils";
 
+const BASE_IRI =
+  process.env.BASE_IRI || "https://publicatie.gelinkt-notuleren.vlaanderen.be/";
 /** @typedef {import('./rdf-utils').Triple} Triple */
 /**
  * Main entry point for extraction of data.
@@ -52,7 +54,7 @@ async function startPipeline(resourceToPublish) {
 function parseRdfaIntoFlatTriples(html) {
   const triples = [];
   const parser = new RdfaParser({
-    baseIRI: "https://www.rubensworks.net/",
+    baseIRI: BASE_IRI,
     contentType: "text/html",
   });
   parser

--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -14,6 +14,7 @@ import {
   insertZittingPermalinkQuery,
 } from "./queries";
 import RdfaDomDocument from "./rdfa-dom-document";
+import { persistContentToFile, writeFileMetadataToDb } from './file-utils';
 
 /**
  * Main entry point for extraction of data.
@@ -241,11 +242,11 @@ async function insertNotulen(triples, resourceToPublish, doc, contexts) {
     predicate: "a",
     object: "http://mu.semte.ch/vocabularies/ext/Notulen",
   });
-  trs.push({
-    subject,
-    predicate: "http://www.w3.org/ns/prov#value",
-    object: enrichNotulen(triples, doc, contexts),
-  });
+    const fileMetadata = await persistContentToFile(doc.getTopDomNode().innerHTML, ['enriched-notulen']);
+  const logicalFileUri = await writeFileMetadataToDb(fileMetadata);
+  // using the prov:generated predicate here to mirror how we link file data to
+  // PublishedResource objects coming from GN
+  trs.push({ subject, predicate: 'http://www.w3.org/ns/prov#generated', object: logicalFileUri });
   linkToZitting(
     trs,
     triples,

--- a/support/queries.js
+++ b/support/queries.js
@@ -295,8 +295,13 @@ function applyEscapeFunctionData(triples) {
     .filter((e) => e);
 }
 
+/**
+ * Checks if a triple is a "<subject> a <type>" triple
+ * The iri's are already assumed to be sparql-escaped
+ * @param {import("./rdf-utils").Triple} triple The ALREADY SPARQL ESCAPED triple to check
+ */
 function isAResource(triple) {
-  return expandURI(triple.predicate) === RDF_TYPE;
+  return triple.predicate === `<${RDF_TYPE}>`;
 }
 
 /**

--- a/support/queries.js
+++ b/support/queries.js
@@ -11,6 +11,7 @@ import {
 } from "mu";
 import { querySudo as query } from "@lblod/mu-auth-sudo";
 import { readFile } from "fs/promises";
+import { expandURI, RDF_TYPE } from "./rdf-utils";
 
 const PENDING_STATUS =
   "http://mu.semte.ch/vocabularies/ext/besluit-publicatie-publish-service/status/pending";
@@ -275,7 +276,9 @@ function applyEscapeFunctionData(triples) {
     .map((t) => {
       const p = predicateDataTypeEscapeMap(t.predicate);
       const escapedPredicate =
-        p.predicate === "a" ? "a" : sparqlEscapeUri(t.predicate);
+        expandURI(p.predicate) === RDF_TYPE
+          ? sparqlEscapeUri(RDF_TYPE)
+          : sparqlEscapeUri(t.predicate);
       try {
         return {
           subject: p.escapeSubjectF(t.subject),
@@ -293,7 +296,7 @@ function applyEscapeFunctionData(triples) {
 }
 
 function isAResource(triple) {
-  return triple.predicate === "a";
+  return expandURI(triple.predicate) === RDF_TYPE;
 }
 
 /**
@@ -315,11 +318,7 @@ const parseResult = function (result) {
 
 const filterPendingTimeout = function (timeout) {
   return (resource) => {
-    if (
-      resource.status !==
-      "http://mu.semte.ch/vocabularies/ext/besluit-publicatie-publish-service/status/pending"
-    )
-      return true;
+    if (expandURI(resource.status) !== PENDING_STATUS) return true;
 
     const modifiedDate = new Date(resource.created);
     const currentDate = new Date();
@@ -334,6 +333,11 @@ const predicateDataTypeEscapeMap = function (predicate) {
     {
       escapeSubjectF: sparqlEscapeUri,
       predicate: "a",
+      escapeObjectF: sparqlEscapeUri,
+    },
+    {
+      escapeSubjectF: sparqlEscapeUri,
+      predicate: RDF_TYPE,
       escapeObjectF: sparqlEscapeUri,
     },
     {
@@ -417,6 +421,11 @@ const predicateDataTypeEscapeMap = function (predicate) {
     },
     {
       escapeSubjectF: sparqlEscapeUri,
+      predicate: RDF_TYPE,
+      escapeObjectF: sparqlEscapeUri,
+    },
+    {
+      escapeSubjectF: sparqlEscapeUri,
       predicate: "http://data.vlaanderen.be/ns/besluit#gebeurtNa",
       escapeObjectF: sparqlEscapeUri,
     },
@@ -480,6 +489,11 @@ const predicateDataTypeEscapeMap = function (predicate) {
     },
     {
       escapeSubjectF: sparqlEscapeUri,
+      predicate: RDF_TYPE,
+      escapeObjectF: sparqlEscapeUri,
+    },
+    {
+      escapeSubjectF: sparqlEscapeUri,
       predicate: "http://data.vlaanderen.be/ns/besluit#onderwerp",
       escapeObjectF: sparqlEscapeString,
     },
@@ -493,6 +507,11 @@ const predicateDataTypeEscapeMap = function (predicate) {
     {
       escapeSubjectF: sparqlEscapeUri,
       predicate: "a",
+      escapeObjectF: sparqlEscapeUri,
+    },
+    {
+      escapeSubjectF: sparqlEscapeUri,
+      predicate: RDF_TYPE,
       escapeObjectF: sparqlEscapeUri,
     },
     {
@@ -551,6 +570,11 @@ const predicateDataTypeEscapeMap = function (predicate) {
     {
       escapeSubjectF: sparqlEscapeUri,
       predicate: "a",
+      escapeObjectF: sparqlEscapeUri,
+    },
+    {
+      escapeSubjectF: sparqlEscapeUri,
+      predicate: RDF_TYPE,
       escapeObjectF: sparqlEscapeUri,
     },
     {
@@ -638,6 +662,11 @@ const predicateDataTypeEscapeMap = function (predicate) {
     },
     {
       escapeSubjectF: sparqlEscapeUri,
+      predicate: RDF_TYPE,
+      escapeObjectF: sparqlEscapeUri,
+    },
+    {
+      escapeSubjectF: sparqlEscapeUri,
       predicate: "http://www.w3.org/ns/prov#value",
       escapeObjectF: sparqlEscapeString,
     },
@@ -657,6 +686,11 @@ const predicateDataTypeEscapeMap = function (predicate) {
     {
       escapeSubjectF: sparqlEscapeUri,
       predicate: "a",
+      escapeObjectF: sparqlEscapeUri,
+    },
+    {
+      escapeSubjectF: sparqlEscapeUri,
+      predicate: RDF_TYPE,
       escapeObjectF: sparqlEscapeUri,
     },
     {
@@ -684,6 +718,11 @@ const predicateDataTypeEscapeMap = function (predicate) {
     },
     {
       escapeSubjectF: sparqlEscapeUri,
+      predicate: RDF_TYPE,
+      escapeObjectF: sparqlEscapeUri,
+    },
+    {
+      escapeSubjectF: sparqlEscapeUri,
       predicate: "http://mu.semte.ch/vocabularies/ext/uittrekselBvap",
       escapeObjectF: sparqlEscapeUri,
     },
@@ -698,6 +737,11 @@ const predicateDataTypeEscapeMap = function (predicate) {
     {
       escapeSubjectF: sparqlEscapeUri,
       predicate: "a",
+      escapeObjectF: sparqlEscapeUri,
+    },
+    {
+      escapeSubjectF: sparqlEscapeUri,
+      predicate: RDF_TYPE,
       escapeObjectF: sparqlEscapeUri,
     },
     {

--- a/support/rdf-utils.js
+++ b/support/rdf-utils.js
@@ -1,0 +1,133 @@
+/**
+ * @typedef {Object} Triple
+ * @property {string} subject
+ * @property {string} predicate
+ * @property {string} object
+ * @property {string?} datatype
+ */
+
+/*
+ * checks if URI (stolen from SO)
+ * @param {string} str
+ * @returns {boolean}
+ */
+export function isURI(str) {
+  return /^https?:\/\/(.*)/.test(str);
+}
+
+/**
+ * Returns a naive ttl representation of a triple.
+ * TODO: this ignores languages, but that's how it's always been in this service
+ *
+ * @param {Triple} triple
+ * @returns {string}
+ */
+export function hashTriple({ subject, predicate, object, datatype }) {
+  const hashSubject = isURI(subject) ? `<${subject}>` : subject;
+  const hashPredicate = isURI(predicate) ? `<${predicate}>` : predicate;
+  let hashObject;
+  if (isURI(object)) {
+    hashObject = `<${object}>`;
+  } else if (datatype) {
+    if (isURI(datatype)) {
+      hashObject = `"${object}"^^<${datatype}>`;
+    } else {
+      hashObject = `"${object}^^${datatype}`;
+    }
+  } else {
+    hashObject = `"${object}"`;
+  }
+  return `${hashSubject} ${hashPredicate} ${hashObject}`;
+}
+
+/**
+ * @param {Triple[]} triples
+ * @param {string} objectUri
+ * @returns {Triple?}
+ */
+export function findTripleWithObject(triples, objectUri) {
+  return triples.find((t) => t.object === objectUri);
+}
+
+/**
+ * @param {Triple[]} triples
+ * @returns {Triple[]}
+ */
+export function dedupeTriples(triples) {
+  const seenTriples = new Set();
+  const deduped = [];
+  for (const triple of triples) {
+    if (!seenTriples.has(hashTriple(triple))) {
+      deduped.push(triple);
+      seenTriples.add(hashTriple(triple));
+    }
+  }
+  return deduped;
+}
+const DEFAULT_PREFIX_MAP = new Map([
+  ["ext", "http://mu.semte.ch/vocabularies/ext/"],
+  ["mu", "http://mu.semte.ch/vocabularies/core/"],
+  ["muSession", "http://mu.semte.ch/vocabularies/session/"],
+  ["tmp", "http://mu.semte.ch/vocabularies/tmp/"],
+  ["besluit", "http://data.vlaanderen.be/ns/besluit#"],
+  ["bv", "http://data.vlaanderen.be/ns/besluitvorming#"],
+  ["mandaat", "http://data.vlaanderen.be/ns/mandaat#"],
+  ["persoon", "http://data.vlaanderen.be/ns/persoon#"],
+  ["generiek", "http://data.vlaanderen.be/ns/generiek#"],
+  ["mobiliteit", "https://data.vlaanderen.be/ns/mobiliteit#"],
+  [
+    "publicationStatus",
+    "http://mu.semte.ch/vocabularies/ext/signing/publication-status/",
+  ],
+  ["eli", "http://data.europa.eu/eli/ontology#"],
+  ["m8g", "http://data.europa.eu/m8g/"],
+  ["dct", "http://purl.org/dc/terms/"],
+  ["cpsv", "http://purl.org/vocab/cpsv#"],
+  ["dul", "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#"],
+  ["adms", "http://www.w3.org/ns/adms#"],
+  ["person", "http://www.w3.org/ns/person#"],
+  ["org", "http://www.w3.org/ns/org#"],
+  ["prov", "http://www.w3.org/ns/prov#"],
+  ["regorg", "https://www.w3.org/ns/regorg#"],
+  ["skos", "http://www.w3.org/2004/02/skos/core#"],
+  ["foaf", "http://xmlns.com/foaf/0.1/"],
+  ["nao", "http://www.semanticdesktop.org/ontologies/2007/08/15/nao#"],
+  ["pav", "http://purl.org/pav/"],
+  ["schema", "http://schema.org/"],
+  ["rdfs", "http://www.w3.org/2000/01/rdf-schema#"],
+  ["sign", "http://mu.semte.ch/vocabularies/ext/signing/"],
+  ["lblodlg", "http://data.lblod.info/vocabularies/leidinggevenden/"],
+  ["lblodmow", "http://data.lblod.info/vocabularies/mobiliteit/"],
+  ["locn", "http://www.w3.org/ns/locn#"],
+  ["adres", "https://data.vlaanderen.be/ns/adres#"],
+  ["persoon", "http://data.vlaanderen.be/ns/persoon#"],
+  ["notulen", "http://lblod.data.gift/vocabularies/notulen/"],
+  ["nfo", "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#"],
+  ["nie", "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#"],
+  ["dbpedia", "http://dbpedia.org/ontology/"],
+  ["besluittype", "https://data.vlaanderen.be/id/concept/BesluitType/"],
+]);
+export const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+/**
+ * @param {string} uri
+ */
+export function expandURI(uri, prefixMap = DEFAULT_PREFIX_MAP) {
+  if (isURI(uri)) {
+    return uri;
+  }
+  if (uri === "a") {
+    return RDF_TYPE;
+  }
+  const split = uri.split(":");
+  if (split.length > 1) {
+    const prefix = split[0];
+    const expansion = prefixMap.get(prefix);
+    if (expansion) {
+      return `${expansion}${split.slice(1).join(":")}`;
+    }
+    console.warn(
+      `Prefix ${prefix} not found in given prefixMap ${prefixMap}, not expanding uri: ${uri}`,
+    );
+  }
+  return uri;
+}

--- a/support/rdf-utils.js
+++ b/support/rdf-utils.js
@@ -109,17 +109,23 @@ const DEFAULT_PREFIX_MAP = new Map([
 ]);
 export const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 /**
- * @param {string} uri
+ * @param {string?} uri
  */
 export function expandURI(uri, prefixMap = DEFAULT_PREFIX_MAP) {
+  if (typeof uri !== "string") {
+    return uri;
+  }
   if (isURI(uri)) {
     return uri;
   }
   if (uri === "a") {
     return RDF_TYPE;
   }
+  if (/\s/.test(uri)) {
+    return uri;
+  }
   const split = uri.split(":");
-  if (split.length > 1) {
+  if (split.length === 2) {
     const prefix = split[0];
     const expansion = prefixMap.get(prefix);
     if (expansion) {

--- a/support/rdfa-dom-document.js
+++ b/support/rdfa-dom-document.js
@@ -5,10 +5,34 @@
 import jsdom from "jsdom";
 
 class RdfaDomDocument {
+  /**
+   * @private
+   * @type {string}
+   */
+  content;
+
+  /**
+   * @private
+   * @type {HTMLHtmlElement?}
+   */
+  dom;
+
+  /**
+   * @private
+   * @type {HTMLBodyElement?}
+   */
+  topDomNode;
+
+  /**
+   * @param {string} content
+   */
   constructor(content) {
     this.content = content;
   }
 
+  /**
+   * @returns {HTMLHtmlElement}
+   */
   getDom() {
     if (this.dom) {
       return this.dom;
@@ -19,6 +43,9 @@ class RdfaDomDocument {
     return dom;
   }
 
+  /**
+   * @returns {HTMLBodyElement}
+   */
   getTopDomNode() {
     if (this.topDomNode) {
       return this.topDomNode;
@@ -29,6 +56,9 @@ class RdfaDomDocument {
     return topDomNode;
   }
 
+  /**
+   * @returns {void}
+   */
   resetDom() {
     this.dom = undefined;
     this.topDomNode = undefined;


### PR DESCRIPTION

By removing the marawa lib and replacing it with the streaming rdfa parser,
we can greatly reduce the processing time. From profiling tests, this 
reduces the time to process a large (70+ item) meeting to about 6 seconds, 
down from 2 hours. This is due to marawa being quite slow since it calculates a lot of extra information which we don't actually need, 
but most of the time gained was actually removing the need to flatten 
the triple array, as Marawa generates a TON of duplicate triples, so this operation took an insane amount of time.
The 2 hour time is also not accurate, as the service did produce some errors
that lead to the document not publishing correctly

I couldn't figure out what the original cause of the crash was, but 
it no longer seems to occur in this optimized version. I'm assuming some 
memory or time limits were reached due to the processing taking so long, but 
it could still be something else.

## challenges

I originally made many more changes to this service, but ultimately reverted
them to get this PR actually out. It seems to do a lot of 
processing which doesn't seem immediately useful. 

Additionally, this service uses a non-rdfjs compliant form of triples,
which lead to a rather hacky implementation of a URI-expanding util (
since it only stores strings, we don't actually know which strings are supposed to be NamedNodes).

## Setup

part of https://github.com/lblod/app-gn-publicatie/pull/37
detailed setup available there

