### PR TITLE
Find decision nodes in rdfa-aware documents

### DIFF
--- a/support/annotate-decisions.js
+++ b/support/annotate-decisions.js
@@ -6,12 +6,27 @@ import { expandURI } from "./rdf-utils";
 
 function enrichBesluit(dom, besluitIRI, triples) {
   const { document } = new JSDOM("").window;
-  const behandeling = triples.find(
+  // There should be one, but in case the document is in a weird state
+  const behandelingen = triples.filter(
     (t) =>
       expandURI(t.object) === expandURI(besluitIRI) &&
       expandURI(t.predicate) === "http://www.w3.org/ns/prov#generated",
   );
-  if (behandeling) {
+  let agendapuntTriple;
+  let behandeling
+  for (const bh of behandelingen) {
+    // Find the first one which is linked to an AP
+    agendapuntTriple = triples.find(
+      (t) =>
+        expandURI(t.subject) === expandURI(bh.subject) &&
+        expandURI(t.predicate) === "http://purl.org/dc/terms/subject",
+    );
+    if (agendapuntTriple) {
+      behandeling = bh;
+      break;
+    }
+  }
+  if (behandeling && agendapuntTriple) {
     const generatedLink = document.createElement("link");
     generatedLink.setAttribute("property", "prov:wasGeneratedBy");
     generatedLink.setAttribute("resource", behandeling.subject);
@@ -21,12 +36,7 @@ function enrichBesluit(dom, besluitIRI, triples) {
       (t) =>
         expandURI(t.object) === "http://data.vlaanderen.be/ns/besluit#Zitting",
     ); // TODO: assumes one zitting!
-    const agendapuntTriple = triples.find(
-      (t) =>
-        expandURI(t.subject) === expandURI(behandeling.subject) &&
-        expandURI(t.predicate) === "http://purl.org/dc/terms/subject",
-    );
-    if (agendapuntTriple && zittingTriple) {
+    if (zittingTriple) {
       const agendapuntToZitting = document.createElement("link");
       agendapuntToZitting.setAttribute("about", zittingTriple.subject);
       agendapuntToZitting.setAttribute(

--- a/support/annotate-decisions.js
+++ b/support/annotate-decisions.js
@@ -73,7 +73,10 @@ export function annotateDecisions(doc, triples) {
   // this is a rough selection which won't work in all cases, but I hope
   // to eliminate this whole fudzing around by skipping most of the parsing this
   // service does
-  const decisionNodes = dom.querySelectorAll(`[typeof~="${decisionType}"]`);
+  const decisionNodes = dom.querySelectorAll(
+    // typeof is for pre-rdfa-aware documents, the chain is to catch those
+    `[typeof~="${decisionType}"], [about] > [data-rdfa-container=true] > [resource~="${decisionType}"]`
+  );
   for (const node of decisionNodes) {
     const decisionIRI =
       node.getAttribute("about") ?? node.getAttribute("resource");


### PR DESCRIPTION
The RDFa in documents made by RDFa-aware versions of the editor no longer use a `typeof` to mark the decision, so look for the newer structure too. Ideally, this wouldn't be hard-coded...

Part of [binnenland.atlassian.net/browse/GN-5633](https://binnenland.atlassian.net/browse/GN-5633)
Along with https://github.com/lblod/notulen-prepublish-service/pull/127 allows decision parsing to work.
RDFa improved by https://github.com/lblod/app-reglementaire-bijlage/pull/95
and https://github.com/lblod/app-gelinkt-notuleren/pull/234

### Setup
To test properly, it's necessary to test with a publisher stack consuming from a GN stack (optionally with an RB stack for templates, [see the RB PR](https://github.com/lblod/app-reglementaire-bijlage/pull/95)).
To set up the stacks, you should be able to use the [example config in the GN repo](https://github.com/lblod/app-gelinkt-notuleren/blob/master/docker-compose.override.example.yml) and then the [matching config in the publicatie repo](https://github.com/lblod/app-gn-publicatie/blob/master/docker-compose.override.example.yml).
- It's important to test with the [prepublisher PR](https://github.com/lblod/notulen-prepublish-service/pull/127) version running in the GN stack.
- Running with the master GN (so without the migrations in the PR) should work but will produce RDFa with an extra incorrect triple, so ideally both situations should be tested (to simulate older documents being published).

### Testing
- In GN, create a new meeting with at least one AP.
- Edit the AP to ensure that it contains a decision with a title and a description.
- Publish the extract for any AP you want to test, but do not publish any other parts of the meeting.
- Go to the publications frontend and verify that the title and description appear correctly for the extract that you published.
- Then verify that publishing all other parts of the meeting still work as expected.