### PR TITLE
Add linked decision to the predicates to be parsed

### DIFF
--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -526,6 +526,7 @@ function getBesluiten(triples) {
     "http://www.w3.org/ns/prov#wasDerivedFrom",
     "http://mu.semte.ch/vocabularies/ext/besluitPublicatieLinkedBesluit",
     "http://data.europa.eu/eli/ontology#related_to",
+    "http://mu.semte.ch/vocabularies/ext/linkedDecision",
   ];
 
   trs = triples.filter(

--- a/support/queries.js
+++ b/support/queries.js
@@ -416,6 +416,11 @@ const predicateDataTypeEscapeMap = function (predicate) {
       predicate: "http://data.europa.eu/eli/ontology#related_to",
       escapeObjectF: sparqlEscapeUri,
     },
+    {
+      escapeSubjectF: sparqlEscapeUri,
+      predicate: "http://mu.semte.ch/vocabularies/ext/linkedDecision",
+      escapeObjectF: sparqlEscapeUri,
+    },
   ];
 
   const bvap = [


### PR DESCRIPTION
Add the new predicate ext:linkedDecision to the list of predicates we parse in besluits.
This will be used for both the sparql endpoint consumption and the frontend gn publicatie in the reglementen view.
In order to test this just verify that when you consume a besluit with this predicate it gets correctly added to the database
